### PR TITLE
Button Customization: Text/Bg Color, Button Labels, and Bug Fixes

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -13,5 +13,7 @@
 * v0.2.2
  - Actually enable support for early Anki versions (tested in 2.1.15)
 * v0.3.0
- - Enabled customization of button colors/names, functional in Anki 24.04.1, PyQT6
- - May not be fully functional in other versions
+ - Enabled customization of button colors/names, functional in Anki 24.04.1 Qt5/6
+ - Also functional in Anki 23.10.1 Qt6
+ - Also functional in Anki 2.1.66 Qt5
+ - May not be fully functional in earlier versions

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -23,4 +23,4 @@
 * v0.3.2
  - Fixed v0.2.2 errors on 2.1.40
  - Appears to support the versions versions from 2.1.15 to 24.04.1
- - Still need to investigate the 23.10.1 Qt5 upstream user-reported issue
+ - Unable to replicate the 23.10.1 Qt5 upstream user-reported issue

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -12,3 +12,6 @@
  - Fixed a bug causing incorrect ease and possible interference with other addons
 * v0.2.2
  - Actually enable support for early Anki versions (tested in 2.1.15)
+* v0.3.0
+ - Enabled customization of button colors/names, functional in Anki 24.04.1, PyQT6
+ - May not be fully functional in other versions

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -17,3 +17,6 @@
  - Also functional in Anki 23.10.1 Qt6
  - Also functional in Anki 2.1.66 Qt5
  - May not be fully functional in earlier versions
+* v0.3.1
+ - Fixed errors, now also supporting 2.1.15
+ - Not sure about other versions in between 2.1.15 and 24.04.1

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -20,3 +20,7 @@
 * v0.3.1
  - Fixed errors, now also supporting 2.1.15
  - Not sure about other versions in between 2.1.15 and 24.04.1
+* v0.3.2
+ - Fixed v0.2.2 errors on 2.1.40
+ - Appears to support the versions versions from 2.1.15 to 24.04.1
+ - Still need to investigate the 23.10.1 Qt5 upstream user-reported issue

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -12,15 +12,3 @@
  - Fixed a bug causing incorrect ease and possible interference with other addons
 * v0.2.2
  - Actually enable support for early Anki versions (tested in 2.1.15)
-* v0.3.0
- - Enabled customization of button colors/names, functional in Anki 24.04.1 Qt5/6
- - Also functional in Anki 23.10.1 Qt6
- - Also functional in Anki 2.1.66 Qt5
- - May not be fully functional in earlier versions
-* v0.3.1
- - Fixed errors, now also supporting 2.1.15
- - Not sure about other versions in between 2.1.15 and 24.04.1
-* v0.3.2
- - Fixed v0.2.2 errors on 2.1.40
- - Appears to support the versions versions from 2.1.15 to 24.04.1
- - Unable to replicate the 23.10.1 Qt5 upstream user-reported issue

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-pyfiles = __init__.py passfail2.py
+pyfiles = __init__.py passfail2.py configuration_menu.py button_color.py config.json
 version = 0.2.2
 
 outfile = passfail2-$(version).ankiaddon

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 pyfiles = __init__.py passfail2.py configuration_menu.py button_color.py config.json
-version = 0.3.2
+version = 0.2.2
 
 outfile = passfail2-$(version).ankiaddon
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 pyfiles = __init__.py passfail2.py configuration_menu.py button_color.py config.json
-version = 0.2.2
+version = 0.3.2
 
 outfile = passfail2-$(version).ankiaddon
 

--- a/README.org
+++ b/README.org
@@ -17,6 +17,11 @@ The goal of this addon is twofold:
     time to forget it. Pass/Fail 2 counters this design by simply
     removing the Hard button in the first place.
 
+As of version v0.3.0, this add-on now supports custom colors and text on your buttons!
+Just go to add-ons > pass / fail 2 > config and modify the buttons as you please.
+Then, close and re-open Anki, and your changes should be reflected!
+
+
 [[./images/passfail.png]]
 
 Intended to be used with settings from [[https://refold.la/roadmap/stage-1/a/anki-setup#Low-key-Low-key-Anki]["Low-Key" Low-Key Anki]], but can also be used without.

--- a/button_color.py
+++ b/button_color.py
@@ -1,0 +1,69 @@
+try:
+    from anki.scheduler.v3 import Scheduler as V3Scheduler
+    import aqt
+    from aqt.utils import tr
+    from aqt import mw
+except Exception as e1:
+    print("Issue with Pass / Fail: " + str(e1))
+
+
+def answer_buttons_with_bgcolor(self) -> str:
+    try:
+        config = mw.addonManager.getConfig(__name__)
+    except Exception as e:
+        print("Issue with Pass / Fail: " + str(e))
+
+    default = self._defaultEase()
+
+    assert isinstance(self.mw.col.sched, V3Scheduler)
+    labels = self.mw.col.sched.describe_next_states(self._v3.states)
+
+    def but(i: int, label: str) -> str:
+        if i == default:
+            extra = """id="defease" """
+        else:
+            extra = ""
+
+        ## inserted ##
+
+        answer_button_background_color = '#ffffff'
+        if font_tag_stripper(label) == config['again_button_name']:
+            answer_button_background_color = config['again_button_bgcolor']
+        elif font_tag_stripper(label) == config['good_button_name']:
+            answer_button_background_color = config['good_button_bgcolor']
+
+        ## inserted ##
+
+        due = self._buttonTime(i, v3_labels=labels)
+        key = (
+            tr.actions_shortcut_key(val=aqt.mw.pm.get_answer_key(i))
+            if aqt.mw.pm.get_answer_key(i)
+            else ""
+        )
+        return f"""<td align=center> <button %s title="%s" data-ease="%s" onclick='pycmd("ease%d");'
+        style="background-color: %s;">%s%s</button></td>""" % (  # inserted style
+            extra,
+            key,
+            i,
+            i,
+            answer_button_background_color,  # inserted
+            label,
+            due,
+        )
+
+    buf = "<center><table cellpadding=0 cellspacing=0><tr>"
+    for ease, label in self._answerButtonList():
+        buf += but(ease, label)
+    buf += "</tr></table>"
+    print(label)
+    print(config['again_button_name'])
+    return buf
+
+
+def font_tag_stripper(input_string):
+    pass
+    if len(input_string) > 28:
+        if input_string[-7:] == "</font>":
+            return input_string[22:-7]
+    else:
+        return input_string

--- a/button_color.py
+++ b/button_color.py
@@ -100,6 +100,7 @@ def answer_buttons_bgcolor_2_1_15(self):
     buf += "</tr></table>"
     script = """
 <script>$(function () { $("#defease").focus(); });</script>"""
+    print(buf)
     return buf + script
 
 

--- a/button_color.py
+++ b/button_color.py
@@ -3,12 +3,12 @@ try:
     import aqt
     from aqt.utils import tr
 except Exception as e1:
-    print("Issue with Pass / Fail: " + str(e1))
+    print("pf logger: 2-" + str(e1))
 
 try:
     from aqt import mw
 except Exception as e1:
-    print("Issue with Pass / Fail: " + str(e1))
+    print("pf logger: 3-" + str(e1))
 
 
 
@@ -100,7 +100,6 @@ def answer_buttons_bgcolor_2_1_15(self):
     buf += "</tr></table>"
     script = """
 <script>$(function () { $("#defease").focus(); });</script>"""
-    print(buf)
     return buf + script
 
 

--- a/button_color.py
+++ b/button_color.py
@@ -59,6 +59,46 @@ def answer_buttons_with_bgcolor(self) -> str:
     print(config['again_button_name'])
     return buf
 
+def answer_buttons_bgcolor_2_1_15(self):
+    try:
+        config = mw.addonManager.getConfig(__name__)
+    except Exception as e:
+        print("Issue with Pass / Fail: " + str(e))
+
+    ## inserted ##
+
+    answer_button_background_color = '#ffffff'
+
+
+    ## inserted ##
+
+    default = self._defaultEase()
+    def but(i, label, bgcolor='#ffffff'):
+        if i == default:
+            extra = "id=defease"
+        else:
+            extra = ""
+        due = self._buttonTime(i)
+        return '''
+<td align=center>%s<button %s style="background-color: %s" title="%s" data-ease="%s" onclick='pycmd("ease%d");'>\
+%s</button></td>''' % (due, extra, answer_button_background_color, _("Shortcut key: %s") % i, i, i, label)
+    buf = "<center><table cellpading=0 cellspacing=0><tr>"
+    for ease, label in self._answerButtonList():
+
+        if font_tag_stripper(label) == config['again_button_name']:
+            answer_button_background_color = config['again_button_bgcolor']
+        elif font_tag_stripper(label) == config['good_button_name']:
+            answer_button_background_color = config['good_button_bgcolor']
+
+
+        buf += but(ease, label,answer_button_background_color)
+    buf += "</tr></table>"
+    script = """
+<script>$(function () { $("#defease").focus(); });</script>"""
+    return buf + script
+
+
+
 
 def font_tag_stripper(input_string):
     pass

--- a/button_color.py
+++ b/button_color.py
@@ -2,9 +2,14 @@ try:
     from anki.scheduler.v3 import Scheduler as V3Scheduler
     import aqt
     from aqt.utils import tr
+except Exception as e1:
+    print("Issue with Pass / Fail: " + str(e1))
+
+try:
     from aqt import mw
 except Exception as e1:
     print("Issue with Pass / Fail: " + str(e1))
+
 
 
 def answer_buttons_with_bgcolor(self) -> str:

--- a/config.json
+++ b/config.json
@@ -1,0 +1,10 @@
+{
+  "toggle_names_textcolors": "0",
+  "again_button_name": "Fail",
+  "good_button_name": "Pass",
+  "again_button_textcolor": "#000000",
+  "good_button_textcolor": "#000000",
+  "toggle_bgcolor": "0",
+  "again_button_bgcolor": "#de0d0d",
+  "good_button_bgcolor": "#26a269"
+}

--- a/configuration_menu.py
+++ b/configuration_menu.py
@@ -3,7 +3,7 @@ try:
     from aqt.qt import *
     from . import passfail2
 except Exception as e1:
-    print("Issue with Pass / Fail: " + str(e1))
+    print("pf logger: 1-" + str(e1))
 
 
 class SettingsDialog(QDialog):

--- a/configuration_menu.py
+++ b/configuration_menu.py
@@ -1,0 +1,337 @@
+try:
+    from aqt import mw
+    from aqt.qt import *
+    from . import passfail2
+except Exception as e1:
+    print("Issue with Pass / Fail: " + str(e1))
+
+
+class SettingsDialog(QDialog):
+    def __init__(self, parent=None):
+        super(SettingsDialog, self).__init__(parent)
+        self.preview_config = read_config()
+        self.error_label = None
+        self.mainWindow()
+
+    def mainWindow(self):
+        self.setWindowTitle("Pass / Fail 2 v0.3.0")
+        self.setMinimumWidth(500)
+
+        scroll_area = QScrollArea(self)
+        scroll_area.setWidgetResizable(True)  # Ensures that the widget inside the scroll area resizes correctly
+
+        # Create a widget to hold the layout
+        widget = QWidget()
+        scroll_area.setWidget(widget)
+
+        layout = QVBoxLayout(widget)
+
+        # text
+        # Adding subtitle
+        subtitle_label = QLabel("Credits: Ashlynn Anderson, Dmitry Mikheev, and Rohan Modi", self)
+        subtitle_label.setStyleSheet("font-size: 12px; font-style: italic;")
+        layout.addWidget(subtitle_label)
+
+        # Adding paragraph
+        paragraph_label = QLabel("This add-on replaces the original answer options with just two, which correspond to again, and good. This helps avoid issues such as ease hell, and helps eliminate the stress from grading. If you'd like, you can use the following options to enable custom coloring and naming of the two buttons. On some versions of Anki, the background color customization may not work, so you are free to toggle it, if it breaks things. There are two preview buttons, which reflect what the colorscheme of your buttons would look like, if you had both tickboxes checked. \n\n Remember to save your changes, and restart anki to see your changes take effect.", self)
+        paragraph_label.setWordWrap(True)
+        layout.addWidget(paragraph_label)
+
+        # first toggle switch
+        # Adding first toggle switch
+        self.toggle_names_textcolors = QCheckBox("Toggle Renaming and Custom TextColors", self)
+        self.toggle_names_textcolors.stateChanged.connect(self.toggleInputs1)
+        layout.addWidget(self.toggle_names_textcolors)
+
+        # Text input boxes with labels
+        again_button_name = QHBoxLayout()
+        again_button_name.addWidget(QLabel("'Again' Name", self))
+        self.again_button_name = QLineEdit(self)
+        self.again_button_name.setPlaceholderText("Default: Fail")
+        again_button_name.addWidget(self.again_button_name)
+        layout.addLayout(again_button_name)
+
+        good_button_name = QHBoxLayout()
+        good_button_name.addWidget(QLabel("'Good' Name", self))
+        self.good_button_name = QLineEdit(self)
+        self.good_button_name.setPlaceholderText("Default: Pass")
+        good_button_name.addWidget(self.good_button_name)
+        layout.addLayout(good_button_name)
+
+        again_button_textcolor = QHBoxLayout()
+        again_button_textcolor.addWidget(QLabel("'Again' TextColor", self))
+        self.again_button_textcolor = QLineEdit(self)
+        self.again_button_textcolor.setPlaceholderText("Default: #000000")
+        again_button_textcolor.addWidget(self.again_button_textcolor)
+
+        # Adding button 1
+        self.again_textcolor_picker = QPushButton("Color Picker", self)
+        self.again_textcolor_picker.setEnabled(False)  # Initially disabled
+        self.again_textcolor_picker.clicked.connect(lambda: self.colorPick(1))
+        again_button_textcolor.addWidget(self.again_textcolor_picker)
+        layout.addLayout(again_button_textcolor)
+
+        good_button_textcolor = QHBoxLayout()
+        good_button_textcolor.addWidget(QLabel("'Good' Textcolor", self))
+        self.good_button_textcolor = QLineEdit(self)
+        self.good_button_textcolor.setPlaceholderText("Default: #000000")
+        good_button_textcolor.addWidget(self.good_button_textcolor)
+
+        # Adding button 2
+        self.good_textcolor_picker = QPushButton("Color Picker", self)
+        self.good_textcolor_picker.setEnabled(False)  # Initially disabled
+        self.good_textcolor_picker.clicked.connect(lambda: self.colorPick(2))
+        good_button_textcolor.addWidget(self.good_textcolor_picker)
+
+        layout.addLayout(good_button_textcolor)
+
+        # second toggle switch
+
+        self.toggle_bgcolor = QCheckBox("Toggle Background Color", self)
+        self.toggle_bgcolor.stateChanged.connect(self.toggleInputs2)
+        layout.addWidget(self.toggle_bgcolor)
+
+        # Additional text input boxes with labels
+        again_button_bgcolor = QHBoxLayout()
+        again_button_bgcolor.addWidget(QLabel("'Again' BG Color", self))
+        self.again_button_bgcolor = QLineEdit(self)
+        self.again_button_bgcolor.setPlaceholderText("Default: #de0d0d")
+        again_button_bgcolor.addWidget(self.again_button_bgcolor)
+
+        # Adding button 4
+        self.again_bgcolor_picker = QPushButton("Color Picker", self)
+        self.again_bgcolor_picker.setEnabled(False)  # Initially disabled
+        self.again_bgcolor_picker.clicked.connect(lambda: self.colorPick(3))
+        again_button_bgcolor.addWidget(self.again_bgcolor_picker)
+
+        layout.addLayout(again_button_bgcolor)
+
+        good_button_bgcolor = QHBoxLayout()
+        good_button_bgcolor.addWidget(QLabel("'Good' BG Color", self))
+        self.good_button_bgcolor = QLineEdit(self)
+        self.good_button_bgcolor.setPlaceholderText("Default: #26a269")
+        good_button_bgcolor.addWidget(self.good_button_bgcolor)
+
+        # Adding button 3
+        self.good_bgcolor_picker = QPushButton("Color Picker", self)
+        self.good_bgcolor_picker.setEnabled(False)  # Initially disabled
+        self.good_bgcolor_picker.clicked.connect(lambda: self.colorPick(4))
+        good_button_bgcolor.addWidget(self.good_bgcolor_picker)
+
+        layout.addLayout(good_button_bgcolor)
+
+        preview_buttons_layout = QHBoxLayout()
+
+        # Again Preview Button
+        self.again_preview = QPushButton(self.preview_config['again_button_name'], self)
+        self.again_preview.setStyleSheet(
+            "color: " + self.preview_config['again_button_textcolor'] + "; background-color: " + self.preview_config[
+                'again_button_bgcolor'])
+        preview_buttons_layout.addWidget(self.again_preview)
+
+        # Good Preview Button
+        self.good_preview = QPushButton(self.preview_config['good_button_name'], self)
+        self.good_preview.setStyleSheet(
+            "color: " + self.preview_config['good_button_textcolor'] + "; background-color: " + self.preview_config[
+                'good_button_bgcolor'])
+        preview_buttons_layout.addWidget(self.good_preview)
+
+        layout.addLayout(preview_buttons_layout)
+
+        label_buttons_layout = QHBoxLayout()
+        paragraph_label = QLabel("Press Preview to Refresh the Above Preview Buttons, and Save to Save.")
+        label_buttons_layout.addWidget(paragraph_label)
+        layout.addLayout(label_buttons_layout)
+
+        # Adding centered buttons next to each other
+        bottom_buttons_layout = QHBoxLayout()
+
+        # Again Preview Button
+
+        self.cancel_changes = QPushButton("Cancel Changes", self)
+        self.cancel_changes.clicked.connect(lambda: self.close_config_window())
+        bottom_buttons_layout.addWidget(self.cancel_changes)
+
+        self.preview_refresh = QPushButton("Refresh the Previews", self)
+        self.preview_refresh.clicked.connect(lambda: self.update_preview_config())
+        bottom_buttons_layout.addWidget(self.preview_refresh)
+
+        # Good Preview Button
+        self.save_button = QPushButton("Save Changes", self)
+        self.save_button.clicked.connect(lambda: self.write_config())
+        bottom_buttons_layout.addWidget(self.save_button)
+
+        layout.addLayout(bottom_buttons_layout)
+
+        error_message_layout = QHBoxLayout()
+        self.error_label = QLabel(
+            "There is an error with one of the fields you inputted. All names must be 0-15 Characters, and all colors must be in valid hex format, beginning with a #. They should be 7 characters long including the #.")
+        self.error_label.setStyleSheet("color: red;")
+        self.error_label.setWordWrap(True)
+        error_message_layout.addWidget(self.error_label)
+        layout.addLayout(error_message_layout)
+
+        ################
+
+        main_layout = QVBoxLayout(self)
+        main_layout.addWidget(scroll_area)
+        self.setLayout(main_layout)
+
+        # Set default states
+
+        self.prepopulate_fields()
+        self.error_label.hide()
+        print(str(self.toggle_names_textcolors.checkState()))
+        self.toggleInputs1(self.toggle_names_textcolors.checkState())
+        self.toggleInputs2(self.toggle_bgcolor.checkState())
+
+    def toggleInputs1(self, state):
+        if state == 2 or str(state) == "CheckState.Checked":  # Checked state
+            self.again_button_name.setEnabled(True)
+            self.good_button_name.setEnabled(True)
+            self.again_button_textcolor.setEnabled(True)
+            self.good_button_textcolor.setEnabled(True)
+            self.toggle_bgcolor.setEnabled(True)  # Enable second checkbox
+            self.again_textcolor_picker.setEnabled(True)  # Enable button 1
+            self.good_textcolor_picker.setEnabled(True)  # Enable button 2
+        else:  # Unchecked state
+            self.again_button_name.setEnabled(False)
+            self.good_button_name.setEnabled(False)
+            self.again_button_textcolor.setEnabled(False)
+            self.good_button_textcolor.setEnabled(False)
+            # self.toggle_bgcolor.setChecked(False)  # Uncheck second checkbox
+            # self.toggle_bgcolor.setEnabled(False)  # Disable second checkbox
+            self.again_textcolor_picker.setEnabled(False)  # Disable button 1
+            self.good_textcolor_picker.setEnabled(False)  # Disable button 2
+
+    def toggleInputs2(self, state):
+        if state == 2 or str(state) == "CheckState.Checked":  # Checked state
+            self.again_button_bgcolor.setEnabled(True)
+            self.good_button_bgcolor.setEnabled(True)
+
+            self.good_bgcolor_picker.setEnabled(True)  # Enable button 3
+            self.again_bgcolor_picker.setEnabled(True)  # Enable button 4
+        else:  # Unchecked state
+            self.again_button_bgcolor.setEnabled(False)
+            self.good_button_bgcolor.setEnabled(False)
+
+            self.good_bgcolor_picker.setEnabled(False)  # Disable button 3
+            self.again_bgcolor_picker.setEnabled(False)  # Disable button 4
+
+    def colorPick(self, button_number):
+        color = QColorDialog.getColor()
+        if color.isValid():
+            hex_color = color.name()
+            if button_number == 1:
+                # self.again_textcolor_picker.setStyleSheet(f"background-color: {hex_color};")
+                self.again_button_textcolor.setText(hex_color)
+            elif button_number == 2:
+                # self.good_textcolor_picker.setStyleSheet(f"background-color: {hex_color};")
+                self.good_button_textcolor.setText(hex_color)
+            elif button_number == 3:
+                # self.good_bgcolor_picker.setStyleSheet(f"background-color: {hex_color};")
+                self.again_button_bgcolor.setText(hex_color)
+            elif button_number == 4:
+                # self.again_bgcolor_picker.setStyleSheet(f"background-color: {hex_color};")
+                self.good_button_bgcolor.setText(hex_color)
+
+    def prepopulate_fields(self):
+        config_from_json = read_config()
+
+        self.toggle_names_textcolors.setChecked(bool(int(config_from_json['toggle_names_textcolors'])))
+        self.again_button_name.setText(config_from_json['again_button_name'])
+        self.good_button_name.setText(config_from_json['good_button_name'])
+        self.again_button_textcolor.setText(config_from_json['again_button_textcolor'])
+        self.good_button_textcolor.setText(config_from_json['good_button_textcolor'])
+        self.toggle_bgcolor.setChecked(bool(int(config_from_json['toggle_bgcolor'])))
+        self.again_button_bgcolor.setText(config_from_json['again_button_bgcolor'])
+        self.good_button_bgcolor.setText(config_from_json['good_button_bgcolor'])
+
+        return config_from_json
+
+    def update_preview_config(self):
+
+        if self.current_config_is_valid():
+            self.preview_config = {'toggle_names_textcolors': "1" if self.toggle_names_textcolors.isChecked() else "0",
+                                   'again_button_name': self.again_button_name.text(),
+                                   'good_button_name': self.good_button_name.text(),
+                                   'again_button_textcolor': self.again_button_textcolor.text(),
+                                   'good_button_textcolor': self.good_button_textcolor.text(),
+                                   'toggle_bgcolor': "1" if self.toggle_bgcolor.isChecked() else "0",
+                                   'again_button_bgcolor': self.again_button_bgcolor.text(),
+                                   'good_button_bgcolor': self.good_button_bgcolor.text()}
+            self.error_label.hide()
+            self.update_preview_buttons()
+        else:
+            self.error_label.show()
+
+    def update_preview_buttons(self):
+        self.again_preview.setText(self.preview_config['again_button_name'])
+        self.again_preview.setStyleSheet(
+            "color: " + self.preview_config['again_button_textcolor'] + "; background-color: " + self.preview_config[
+                'again_button_bgcolor'])
+        self.good_preview.setText(self.preview_config['good_button_name'])
+        self.good_preview.setStyleSheet(
+            "color: " + self.preview_config['good_button_textcolor'] + "; background-color: " + self.preview_config[
+                'good_button_bgcolor'])
+
+    def write_config(self):
+        if self.current_config_is_valid():
+            self.update_preview_config()
+            mw.addonManager.writeConfig(__name__, self.preview_config)
+            self.close_config_window()
+
+        else:
+            self.error_label.show()
+
+    def close_config_window(self):
+        self.close()
+
+    def current_config_is_valid(self):
+        is_valid = (is_valid_name(self.again_button_name.text()) and is_valid_name(
+            self.good_button_name.text()) and is_valid_hex_color(
+            self.again_button_textcolor.text()) and is_valid_hex_color(
+            self.good_button_textcolor.text()) and is_valid_hex_color(
+            self.again_button_bgcolor.text()) and is_valid_hex_color(self.good_button_bgcolor.text()))
+        return is_valid
+
+
+def openWindow():
+    settingsDialog = SettingsDialog()
+    settingsDialog.exec()
+
+
+def is_valid_hex_color(hexstring_to_validate):
+    # Check if the string starts with a hashtag and is 7 characters long
+    if len(hexstring_to_validate) != 7 or hexstring_to_validate[0] != '#':
+        return False
+
+    # Define the valid characters
+    valid_chars = set("0123456789abcdefABCDEF")
+
+    # Check if all characters in the string (except the first) are valid
+    for char in hexstring_to_validate[1:]:
+        if char not in valid_chars:
+            return False
+
+    return True
+
+
+def is_valid_name(name_to_validate):
+    if len(name_to_validate) < 15:
+        return True
+    else:
+        return False
+
+
+def read_config():
+
+    current_config_in_memory = mw.addonManager.getConfig(__name__)
+    return current_config_in_memory
+
+
+def configuration_menu_init():
+    try:
+        mw.addonManager.setConfigAction(__name__, openWindow)
+    except Exception as e:
+        print("Issue with Pass / Fail: " + str(e))

--- a/passfail2.py
+++ b/passfail2.py
@@ -168,9 +168,14 @@ def init():
     Reviewer._showEaseButtons = wrap(Reviewer._showEaseButtons, pf2_fix_pass_title, 'after')
 
     # Use the Edited AnswerButtons, to re-draw Buttons, with Background Color Enabled
-    if toggle_bgcolor:
+    if toggle_bgcolor and point_version()>=66: # WHAT IS THE CUTOFF?
         try:
             Reviewer._answerButtons = wrap(Reviewer._answerButtons, button_color.answer_buttons_with_bgcolor, 'after')
         except Exception as e2:
             print("Issue with the BG Color part of Pass / Fail: " + str(e2))
+    elif toggle_bgcolor and point_version() < 66:
+        try:
+            Reviewer._answerButtons = wrap(Reviewer._answerButtons, button_color.answer_buttons_bgcolor_2_1_15, 'after')
+        except Exception as e2:
+            print("Issue with the old BG Color part of Pass / Fail: " + str(e2))
     # End of usage of Edited AnswerButtons

--- a/passfail2.py
+++ b/passfail2.py
@@ -138,7 +138,7 @@ def pf2_fix_pass_title(
     title = None
     if point_version() >= 45:
         title = tr.actions_shortcut_key(val=2)
-    elif point_version() >= 36:
+    elif point_version() >= 41:
         title = tr(TR.ACTIONS_SHORTCUT_KEY, val=2)
     else:
         title = _("Shortcut key: %s") % 2

--- a/passfail2.py
+++ b/passfail2.py
@@ -36,7 +36,7 @@ try:
     from . import button_color
     from . import configuration_menu
 except Exception as e3:
-    print("Issue with Pass / Fail: " + str(e3))
+    print("Issue with Pass / Fail: 4-" + str(e3))
 
 from anki.hooks import wrap
 

--- a/passfail2.py
+++ b/passfail2.py
@@ -14,10 +14,9 @@
 
 try:
     from typing import Literal, Callable
-    from aqt.overview import Overview
     from aqt import mw
-except ImportError:
-    ()
+except ImportError as emp:
+    print(emp)
 
 try:
     from anki.utils import point_version
@@ -45,7 +44,7 @@ if point_version() >= 20:
 
 if point_version() >= 45:
     from aqt.utils import tr
-elif point_version() >= 36:
+elif point_version() >= 41:
     from aqt.utils import tr
     from anki.lang import TR
 else:

--- a/passfail2.py
+++ b/passfail2.py
@@ -14,9 +14,13 @@
 
 try:
     from typing import Literal, Callable
-    from aqt import mw
 except ImportError as emp:
     print(emp)
+
+try:
+    from aqt import mw
+except Exception as except1:
+    print("Error Here Pass Fail: " + str(except1))
 
 try:
     from anki.utils import point_version


### PR DESCRIPTION
I appreciate your creation of this add-on.

I've noticed that the add-on wasn't compatible with a custom-button colors add-on (as expressed in #12), so I implemented my own color customization into the add-on. I added a config-dialog to deal with the new customization, and made it so that my additions were disabled by default. 

The new additions offer an additional layer of customization over the add-on mentioned in #12, since my v0.3.2 version also allows for the change of the background color of the buttons, not just the text, as that add-on does.

Also, #4 requests translation of the buttons. As you hinted at in your reply and #5, that's a lot of work. However, I made it so that you can just easily edit whatever is on the buttons, in the settings dialog.

I've tested the additions, and they are compatible from the latest Flatpak Anki (24.04) down to Anki 2.1.15, which is where the original add-on was tested until, according to the changelog. In doing so, I discovered that the v0.2.2 version-handling had a slight error, so 2.36-2.40 were actually not functional. I corrected that.