### PR TITLE
Don't save config after loading

### DIFF
--- a/config.py
+++ b/config.py
@@ -47,8 +47,7 @@ def load():
                 ()
     except:
         log.warn("Failed to load config. Writing.")
-
-    save()
+        save()
 
 def save():
     mw.addonManager.writeConfig(__name__, _config)


### PR DESCRIPTION
Saving after every load breaks the addon when the files are read-only. This is relevant for Nix packaging.